### PR TITLE
feat: allow server and accession via query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Examples (with proxy):
   - Metadata: field-by-field diffs with word/line-aware highlighting
 - Responsive UI, tab navigation, loading and error states
 - Advanced settings to change server hostname (with CORS warning)
+- Server hostname and accession can be pre-populated via `?server=` and `?accession=` query parameters
 
 ## Project Structure
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,11 @@ import MetadataDiff from './components/MetadataDiff.jsx'
 import { DEFAULT_HOSTNAME, DEFAULT_SEQUENCE_ID, fetchAllVersions } from './utils/dataFetcher.js'
 
 export default function App() {
-  const [hostname, setHostname] = React.useState(DEFAULT_HOSTNAME)
-  const [sequenceId, setSequenceId] = React.useState(DEFAULT_SEQUENCE_ID)
+  const params = React.useMemo(() => new URLSearchParams(window.location.search), [])
+  const initialHostname = params.get('server') || DEFAULT_HOSTNAME
+  const initialSequenceId = params.get('accession') || DEFAULT_SEQUENCE_ID
+  const [hostname, setHostname] = React.useState(initialHostname)
+  const [sequenceId, setSequenceId] = React.useState(initialSequenceId)
   const [versions, setVersions] = React.useState([])
   const [version1, setVersion1] = React.useState(null)
   const [version2, setVersion2] = React.useState(null)


### PR DESCRIPTION
## Summary
- initialize hostname and accession from `server` and `accession` URL query parameters
- document query parameter usage in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8bad5cf1c832582d7c561a1641ffc